### PR TITLE
Fixed Former Alias

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ Stevemo\Cpanel\CpanelServiceProvider
 
 Then add the following Class Aliases
 ```php
-'Former' => 'Former\Facades\Illuminate',
+'Former' => 'Former\Facades\Former',
 'Sentry' => 'Cartalyst\Sentry\Facades\Laravel\Sentry',
 ```
 


### PR DESCRIPTION
Current Former Alias `Former\Facades\Illuminate` throws `Class 'Former\Facades\Illuminate' not found` Error, Fixed with correct alias, i.e `Former\Facades\Former`.
