### PR TITLE
Fix for typing mistake of requireds which should be required 

### DIFF
--- a/src/views/users/create.blade.php
+++ b/src/views/users/create.blade.php
@@ -22,13 +22,13 @@
                 <div class="block-body">
 
                     <legend><small>items mark with * are required.</small></legend>
-                    {{ Former::xlarge_text('first_name', 'First Name')->requireds() }}
-                    {{ Former::xlarge_text('last_name', 'Last Name')->requireds() }}
-                    {{ Former::xlarge_text('email','Email')->requireds() }}
+                    {{ Former::xlarge_text('first_name', 'First Name')->required() }}
+                    {{ Former::xlarge_text('last_name', 'Last Name')->required() }}
+                    {{ Former::xlarge_text('email','Email')->required() }}
 
                     <legend>Password</legend>
-                    {{ Former::xlarge_password('password', 'Password')->requireds() }}
-                    {{ Former::xlarge_password('password_confirmation', 'Confirm Password')->requireds() }}
+                    {{ Former::xlarge_password('password', 'Password')->required() }}
+                    {{ Former::xlarge_password('password_confirmation', 'Confirm Password')->required() }}
 
                     <div class="form-actions">
                         <button type="submit" class="btn btn-primary">Save changes</button>


### PR DESCRIPTION
When creating a new user, the form does not show the red \* for the required fields. This is caused by a typing mistake where requireds() is used instead of the correct typo which should be required().

This problem fixed / Typo corrected with this Pull request.
